### PR TITLE
fix: Add Poipet misspelling

### DIFF
--- a/data/communes.yml
+++ b/data/communes.yml
@@ -1213,7 +1213,7 @@ communes:
   '011002':
     name:
       km: ប៉ោយប៉ែត
-      latin: Paoy Paet
+      latin: Poipet
       ungegn: Paôypêt
     administrative_unit:
       km: សង្កាត់

--- a/data/districts.yml
+++ b/data/districts.yml
@@ -155,7 +155,7 @@ districts:
   '0110':
     name:
       km: ប៉ោយប៉ែត
-      latin: Paoy Paet
+      latin: Poipet
       ungegn: Paôypêt
     administrative_unit:
       km: ក្រុង

--- a/lib/pumi/data_source/ncdd.rb
+++ b/lib/pumi/data_source/ncdd.rb
@@ -26,7 +26,8 @@ module Pumi
         Misspelling.new(incorrect_text: "Taing Kouk", correct_text: "Tang Kouk"),
         Misspelling.new(incorrect_text: "Mongkol Borei", correct_text: "Mongkol Borey"),
         Misspelling.new(incorrect_text: "wat Kor", correct_text: "Wat Kor"),
-        Misspelling.new(incorrect_text: "OMal", correct_text: "Ou Mal")
+        Misspelling.new(incorrect_text: "OMal", correct_text: "Ou Mal"),
+        Misspelling.new(incorrect_text: "Paoy Paet", correct_text: "Poipet")
       ].freeze
 
       AdministrativeUnit = Struct.new(:en, :km, :latin, :ungegn, :code_length, :group, :type, keyword_init: true)


### PR DESCRIPTION
Is the changes sufficient? 

I found more traces via the `grep -r`.

./spec/fixtures/vcr_cassettes/update_wikipedia_communes_in_cambodia_article.yml:        Paet Municipality]]===\n\n\n<div id=district-communes-0110>\nPaoy Paet contains
./spec/fixtures/vcr_cassettes/update_wikipedia_communes_in_cambodia_article.yml:        |title=Paoy Paet |publisher=National Committee for Sub-National Democratic
./spec/fixtures/vcr_cassettes/geocode_cambodian_communes.yml:                       "long_name" : "Paoy Paet",
./spec/fixtures/vcr_cassettes/geocode_cambodian_communes.yml:                       "short_name" : "Paoy Paet",
./spec/fixtures/vcr_cassettes/update_wikipedia_districts_in_cambodia_article.yml:        (ស្រុក Srok)\n| 0109\n|-\n\n| 9\n\n\n| [[Poipet_municipality|Paoy Paet]]\n\n|